### PR TITLE
Add support for trace and measures.

### DIFF
--- a/ppp_datamodel/abstractnode.py
+++ b/ppp_datamodel/abstractnode.py
@@ -98,14 +98,17 @@ class AbstractNode:
     def from_json(cls, data):
         """Decode a JSON string and inflate a node instance."""
         # Decode JSON string
-        if isinstance(data, str):
-            data = json.loads(data)
+        assert isinstance(data, str)
+        data = json.loads(data)
         assert isinstance(data, dict)
+        return cls.from_dict(data)
 
+    @classmethod
+    def from_dict(cls, data):
         cls._test_can_import_json(data)
 
         # Create node instances
-        conv = lambda v: cls.from_json(v) if isinstance(v, dict) else v
+        conv = lambda v: cls.from_dict(v) if isinstance(v, dict) else v
         data = {k: conv(v) for (k, v) in data.items()}
         return TYPE_TO_CLASS[data['type']](**data)
 

--- a/ppp_datamodel/communication.py
+++ b/ppp_datamodel/communication.py
@@ -13,7 +13,9 @@ class Request:
     def __init__(self, language, tree=None, sentence=None):
         assert tree or sentence
         self.sentence = sentence
-        if isinstance(tree, dict) or isinstance(tree, str):
+        if isinstance(tree, dict):
+            tree = AbstractNode.from_dict(tree)
+        elif isinstance(tree, str):
             tree = AbstractNode.from_json(tree)
         self.tree = tree
         self.language = language
@@ -29,15 +31,20 @@ class Request:
                 self.tree == other.tree and \
                 self.sentence == other.sentence
 
-    @staticmethod
-    def from_json(data):
-        if isinstance(data, str):
-            data = json.loads(data)
+    @classmethod
+    def from_json(cls, data):
+        assert isinstance(data, str)
+        data = json.loads(data)
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data):
+        assert isinstance(data, dict)
         if 'tree' not in data and 'sentence' not in data:
             raise KeyError("'tree' or 'sentence'")
-        return Request(data['language'],
-                       data.get('tree', None),
-                       data.get('sentence', None))
+        return cls(data['language'],
+                   data.get('tree', None),
+                   data.get('sentence', None))
 
 
     def as_dict(self):
@@ -50,39 +57,90 @@ class Request:
     def as_json(self):
         return json.dumps(self.as_dict())
 
+class TraceItem:
+    """Represents a trace item.
+    https://github.com/ProjetPP/Documentation/blob/master/module-communication.md#format-of-a-trace-item
+    """
+    __slots__ = ('module', 'tree', 'measures')
+
+    def __init__(self, module, tree, measures):
+        self.module = module
+        self.tree = tree
+        self.measures = measures
+
+    @classmethod
+    def from_json(cls, data):
+        assert isinstance(data, str)
+        data = json.loads(data)
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data):
+        assert isinstance(data, dict)
+        return cls(data['module'],
+                   AbstractNode.from_dict(data['tree']),
+                   data['measures'])
+
+    def as_dict(self):
+        return {'module': self.module,
+                'tree': self.tree.as_dict(),
+                'measures': self.measures,
+               }
+
+    def __repr__(self):
+        return '<PPP traceitem module=%r, tree=%r, measures=%r>' % \
+                (self.module, self.tree, self.measures)
+
+    def __eq__(self, other):
+        return self.module == other.module and \
+                self.tree == other.tree and \
+                self.measures == other.measures
+
+
 class Response:
     """Represents a response.
     https://github.com/ProjetPP/Documentation/blob/master/module-communication.md#response
     """
-    __slots__ = ('language', 'pertinence', 'tree')
+    __slots__ = ('language', 'tree', 'measures', 'trace')
 
-    def __init__(self, language, pertinence, tree):
-        if isinstance(tree, dict) or isinstance(tree, str):
+    def __init__(self, language, tree, measures, trace):
+        if isinstance(tree, dict):
+            tree = AbstractNode.from_dict(tree)
+        elif isinstance(tree, str):
             tree = AbstractNode.from_json(tree)
         self.language = language
-        self.pertinence = pertinence
+        self.measures = measures
         self.tree = tree
+        self.trace = [x if isinstance(x, TraceItem) else TraceItem(x)
+                      for x in trace]
 
     def __repr__(self):
-        return '<PPP response language=%r, pertinence=%r, tree=%r>' % \
-                (self.language, self.pertinence, self.tree)
+        return '<PPP response language=%r, tree=%r, measures=%r, trace=%r>'%\
+                (self.language, self.tree, self.measures, self.trace)
 
     def __eq__(self, other):
         if not isinstance(other, Response):
             return False
         return self.language == other.language and \
-                self.pertinence == other.pertinence and \
-                self.tree == other.tree
+                self.tree == other.tree and \
+                self.measures == other.measures and \
+                self.trace == other.trace
 
-    @staticmethod
-    def from_json(data):
-        if isinstance(data, str):
-            data = json.loads(data)
-        return Response(data['language'], data['pertinence'], data['tree'])
+    @classmethod
+    def from_json(cls, data):
+        data = json.loads(data)
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(data['language'], data['tree'], data['measures'],
+                   list(map(TraceItem.from_dict, data['trace'])))
 
     def as_dict(self):
         return {'language': self.language,
-                'pertinence': self.pertinence,
-                'tree': self.tree.as_dict()}
+                'tree': self.tree.as_dict(),
+                'measures': self.measures,
+                'trace': [x.as_dict() for x in self.trace]
+               }
     def as_json(self):
         return json.dumps(self.as_dict())

--- a/tests/test_abstractnode.py
+++ b/tests/test_abstractnode.py
@@ -46,14 +46,15 @@ class BaseAbstractNodeTests(TestCase):
     def testFromJsonPerfect(self):
         d = {'type': 'triple',
             'subject': r('s'), 'predicate': r('p'), 'object': r('o')}
-        self.assertIsInstance(AbstractNode.from_json(d), Triple)
-        self.assertEqual(d, json.loads(AbstractNode.from_json(d).as_json()))
+        self.assertIsInstance(AbstractNode.from_dict(d), Triple)
+        self.assertIsInstance(AbstractNode.from_json(json.dumps(d)), Triple)
+        self.assertEqual(d, json.loads(AbstractNode.from_dict(d).as_json()))
         self.assertEqual(d, json.loads(AbstractNode.from_json(json.dumps(d)).as_json()))
 
     def testFromJsonMissing(self):
         d = {'type': 'triple',
             'subject': r('s'), 'predicate': r('p')}
-        n = AbstractNode.from_json(d)
+        n = AbstractNode.from_dict(d)
         self.assertEqual(d, json.loads(n.as_json()))
         self.assertEqual(n.predicate, r('p'))
         self.assertNotIn('object', n)
@@ -61,7 +62,7 @@ class BaseAbstractNodeTests(TestCase):
     def testFromJsonNone(self):
         d = {'type': 'triple',
              'subject': r('s'), 'predicate': r('p'), 'object': m()}
-        n = AbstractNode.from_json(d)
+        n = AbstractNode.from_dict(d)
         self.assertEqual(d, json.loads(n.as_json()))
         self.assertIn('object', n)
         self.assertEqual(n.object, M())
@@ -69,13 +70,13 @@ class BaseAbstractNodeTests(TestCase):
     def testFromJsonTypeNotProvided(self):
         d = {'subject': r('s'), 'predicate': r('p'), 'object': m()}
         self.assertRaises(exceptions.AttributeNotProvided,
-                AbstractNode.from_json, d)
+                AbstractNode.from_dict, d)
 
     def testFromJsonTypeInvalid(self):
         d = {'type': 'foobar',
             'subject': r('s'), 'predicate': r('p'), 'object': m()}
         self.assertRaises(exceptions.UnknownNodeType,
-                AbstractNode.from_json, d)
+                AbstractNode.from_dict, d)
 
     def testCheckType(self):
         self.assertRaises(TypeError, Triple, {})

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -1,8 +1,8 @@
 
 import json
 from unittest import TestCase
-from ppp_datamodel import Resource
-from ppp_datamodel.communication import Request, Response
+from ppp_datamodel import Resource, Missing
+from ppp_datamodel.communication import Request, TraceItem, Response
 
 class RequestTest(TestCase):
     def testEquality(self):
@@ -19,27 +19,34 @@ class RequestTest(TestCase):
         j = {'language': 'en',
              'tree': {'type': 'resource', 'value': 'foo'}}
         self.assertEqual(Request('en', Resource(value='foo')),
-                         Request.from_json(j))
+                         Request.from_dict(j))
         self.assertEqual(Request('en', Resource(value='foo')),
                          Request.from_json(json.dumps(j)))
-        self.assertEqual(json.loads(Request.from_json(j).as_json()), j)
+        self.assertEqual(json.loads(Request.from_dict(j).as_json()), j)
 
 class ResponseTest(TestCase):
     def testEquality(self):
-        self.assertEqual(Response('en', 1, Resource(value='foo')),
-                         Response('en', 1, Resource(value='foo')))
-        self.assertNotEqual(Response('en', 1, Resource(value='foo')),
-                            Response('en', 1, Resource(value='bar')))
+        self.assertEqual(Response('en', Resource(value='foo'), {}, []),
+                         Response('en', Resource(value='foo'), {}, []))
+        self.assertNotEqual(Response('en', Resource(value='foo'), {}, []),
+                            Response('en', Resource(value='bar'), {}, []))
+        self.assertNotEqual(Response('en', Resource(value='foo'), {'accuracy': 0.5}, []),
+                            Response('en', Resource(value='foo'), {'accuracy': 0.6}, []))
 
     def testRepr(self):
-        r="<PPP response language='en', pertinence=0.5, tree=<PPP node \"resource\" {'value': 'foo'}>>"
-        self.assertEqual(repr(Response('en', 0.5, Resource(value='foo'))), r)
+        r="<PPP response language='en', tree=<PPP node \"resource\" {'value': 'foo'}>, measures={}, trace=[]>"
+        self.assertEqual(repr(Response('en', Resource(value='foo'), {}, [])), r)
 
     def testFromJson(self):
-        r = {'language': 'en', 'pertinence': 0.5,
+        r = {'language': 'en', 'measures': {},
+             'trace': [{'module': 'foo', 'tree': {'type': 'missing'}, 'measures': {}}],
              'tree': {'type': 'resource', 'value': 'foo'}}
-        self.assertEqual(Response('en', 0.5, Resource(value='foo')),
-                         Response.from_json(r))
-        self.assertEqual(Response('en', 0.5, Resource(value='foo')),
+        t = [TraceItem('foo', Missing(), {})]
+        self.assertEqual(Response('en', Resource(value='foo'), {}, t),
                          Response.from_json(json.dumps(r)))
-        self.assertEqual(json.loads(Response.from_json(r).as_json()), r)
+        self.assertEqual(Response('en', Resource(value='foo'), {}, t),
+                         Response.from_dict(r))
+        self.assertEqual(Response('en', Resource(value='foo'), {}, t),
+                         Response.from_json(json.dumps(r)))
+        self.assertEqual(json.loads(Response.from_dict(r).as_json()), r)
+


### PR DESCRIPTION
This is only administrative change to match the doc.

I also replace the “if it's a string, then convert it to dict first” behavior @Tpt did not like by two different methods (`from_dict` and `from_json`).
