### PR TITLE
Inclusion test

### DIFF
--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -69,3 +69,9 @@ class InclusionAssertion:
             Check wether tree1 is included in tree2.
         """
         return self.isincluded(tree1,tree2,tree1,tree2)
+
+class InclusionTest(unittest.TestCase, InclusionAssertion):
+    """
+        Unit test for inclusion of objects from the datamodel.
+    """
+    pass

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -1,6 +1,6 @@
 """Utilities for using the PPP datamodel."""
 
-from . import Missing
+from . import Resource, Triple, Missing, Intersection, List, Union, And, Or, Exist, First, Last, Sort
 
 def contains_missing(tree):
     def predicate(node, childs):
@@ -9,3 +9,23 @@ def contains_missing(tree):
         else:
             return any(childs.values())
     return tree.fold(predicate)
+
+def isincluded(tree1,tree2):
+    """
+        Return True if and only if tree1 is included in tree2.
+    """
+    if isinstance(tree1,Resource):
+        tree1=List([tree1])
+    if isinstance(tree2,Resource):
+        tree2=List([tree2])
+    if type(tree1) != type(tree2):
+        return False
+    if isinstance(tree1,List):
+        return set(tree1.list).issubset(set(tree2.list))
+    if isinstance(tree1,Triple):
+        return  isincluded(tree1.subject,tree2.subject) and\
+            isincluded(tree1.predicate,tree2.predicate) and\
+            isincluded(tree1.object,tree2.object)
+    if isinstance(tree1,Sort):
+        return tree1.predicate == tree2.predicate and isincluded(tree1.list,tree2.list)
+    return isincluded(tree1.list,tree2.list)

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -10,7 +10,7 @@ def contains_missing(tree):
             return any(childs.values())
     return tree.fold(predicate)
 
-def isincluded(tree1,tree2):
+def isincluded(tree1, tree2):
     """
         Return True if and only if tree1 is included in tree2.
     """
@@ -20,22 +20,24 @@ def isincluded(tree1,tree2):
         tree2=List([tree2])
     if type(tree1) != type(tree2):
         return False
-    if isinstance(tree1,Missing):
+    elif isinstance(tree1, Missing):
         return True
-    if isinstance(tree1,List):
+    elif isinstance(tree1, List):
         return set(tree1.list).issubset(set(tree2.list))
-    if isinstance(tree1,Triple):
-        return  isincluded(tree1.subject,tree2.subject) and\
-            isincluded(tree1.predicate,tree2.predicate) and\
-            isincluded(tree1.object,tree2.object)
-    if isinstance(tree1,Sort):
-        return tree1.predicate == tree2.predicate and isincluded(tree1.list,tree2.list)
-    if isinstance(tree1,First) or isinstance(tree1,Last) or isinstance(tree1,Exists):
-        return isincluded(tree1.list,tree2.list)
-    # Intersection, Union, And, Or
-    if len(tree1.list) != len(tree2.list):
-        return False
-    for elt in tree1.list:
-        if not any(isincluded(elt,x) for x in tree2.list):
+    elif isinstance(tree1, triple):
+        return  isincluded(tree1.subject, tree2.subject) and\
+            isincluded(tree1.predicate, tree2.predicate) and\
+            isincluded(tree1.object, tree2.object)
+    elif isinstance(tree1,Sort):
+        return tree1.predicate == tree2.predicate and isincluded(tree1.list, tree2.list)
+    elif isinstance(tree1,(First, Last, Exists)):
+        return isincluded(tree1.list, tree2.list)
+    elif isinstance(tree1,(Intersection, Union, And, Or)):
+        if len(tree1.list) != len(tree2.list):
             return False
-    return True
+        for elt in tree1.list:
+            if not any(isincluded(elt,x) for x in tree2.list):
+                return False
+        return True
+    else:
+        raise Exception('Unknown class.')

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -1,6 +1,7 @@
 """Utilities for using the PPP datamodel."""
 
 from . import Resource, Triple, Missing, Intersection, List, Union, And, Or, Exists, First, Last, Sort
+import unittest
 
 def contains_missing(tree):
     def predicate(node, childs):
@@ -10,34 +11,61 @@ def contains_missing(tree):
             return any(childs.values())
     return tree.fold(predicate)
 
-def isincluded(tree1, tree2):
-    """
-        Return True if and only if tree1 is included in tree2.
-    """
-    if isinstance(tree1,Resource):
-        tree1=List([tree1])
-    if isinstance(tree2,Resource):
-        tree2=List([tree2])
-    if type(tree1) != type(tree2):
-        return False
-    elif isinstance(tree1, Missing):
-        return True
-    elif isinstance(tree1, List):
-        return set(tree1.list).issubset(set(tree2.list))
-    elif isinstance(tree1, Triple):
-        return  isincluded(tree1.subject, tree2.subject) and\
-            isincluded(tree1.predicate, tree2.predicate) and\
-            isincluded(tree1.object, tree2.object)
-    elif isinstance(tree1,Sort):
-        return tree1.predicate == tree2.predicate and isincluded(tree1.list, tree2.list)
-    elif isinstance(tree1,(First, Last, Exists)):
-        return isincluded(tree1.list, tree2.list)
-    elif isinstance(tree1,(Intersection, Union, And, Or)):
-        if len(tree1.list) != len(tree2.list):
-            return False
-        for elt in tree1.list:
-            if not any(isincluded(elt,x) for x in tree2.list):
-                return False
-        return True
-    else:
-        raise Exception('Unknown class.')
+class InclusionAssertion:
+
+    def isincluded(self,tree1, tree2, originalTree1, originalTree2):
+        """
+            Check wether tree1 is included in tree2.
+            originalTree1 and originalTree2 are the trees given at the call of assertIncluded.
+        """
+        if isinstance(tree1,Resource):
+            tree1=List([tree1])
+        if isinstance(tree2,Resource):
+            tree2=List([tree2])
+        if type(tree1) != type(tree2):
+            raise AssertionError('Different types for %s and %s.\n%s ⊈ %s.' % (tree1, tree2, originalTree1, originalTree2))
+        elif isinstance(tree1, Missing):
+            return
+        elif isinstance(tree1, List):
+            if not set(tree1.list).issubset(set(tree2.list)):
+                raise AssertionError('List %s not included in List %s.\n%s ⊈ %s.' % (tree1, tree2, originalTree1, originalTree2))
+        elif isinstance(tree1, Triple):
+            return  self.isincluded(tree1.subject, tree2.subject, originalTree1, originalTree2) and\
+                self.isincluded(tree1.predicate, tree2.predicate, originalTree1, originalTree2) and\
+                self.isincluded(tree1.object, tree2.object)
+        elif isinstance(tree1,Sort):
+            if tree1.predicate != tree2.predicate:
+                raise AssertionError('Different predicate: %s and %s.\n%s ⊈ %s.' % (tree1.predicate, tree2.predicate, originalTree1, originalTree2))
+            else:
+                return self.isincluded(tree1.list, tree2.list, originalTree1, originalTree2)
+        elif isinstance(tree1,(First, Last, Exists)):
+            return self.isincluded(tree1.list, tree2.list, originalTree1, originalTree2)
+        elif isinstance(tree1,(Intersection, Union, And, Or)):
+            if len(tree1.list) != len(tree2.list):
+                raise AssertionError('Different list length for %s and %s.\n%s ⊈ %s.' % (tree1, tree2, originalTree1, originalTree2))
+            for elt in tree1.list:
+                if not self.contains(elt,tree2.list):
+                    raise AssertionError('%s does not belong to %s.\n%s ⊈ %s.' % (elt, tree2.list, originalTree1, originalTree2))
+            return
+        else:
+            raise Exception('Unknown class.')
+
+    def contains(self,elt,l):
+        """
+            Return True if and only if l contains elt (in the isincluded meaning).
+        """
+        included = False
+        for elt2 in l:
+            try:
+                self.isincluded(elt,elt2,None,None)
+            except AssertionError:
+                continue
+            included = True
+            break
+        return included
+
+    def assertIncluded(self,tree1,tree2):
+        """
+            Check wether tree1 is included in tree2.
+        """
+        return self.isincluded(tree1,tree2,tree1,tree2)

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -69,7 +69,7 @@ class InclusionTestCase(unittest.TestCase):
                             (elt, tree2.list, originalTree1, originalTree2))
             return
         else:
-            raise Exception('Unknown class.')
+            raise TypeError('Object of unknown class: %r' % (tree1,))
 
     def contains(self, elt, l):
         """

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -24,7 +24,7 @@ def isincluded(tree1, tree2):
         return True
     elif isinstance(tree1, List):
         return set(tree1.list).issubset(set(tree2.list))
-    elif isinstance(tree1, triple):
+    elif isinstance(tree1, Triple):
         return  isincluded(tree1.subject, tree2.subject) and\
             isincluded(tree1.predicate, tree2.predicate) and\
             isincluded(tree1.object, tree2.object)

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -33,6 +33,8 @@ def isincluded(tree1,tree2):
     if isinstance(tree1,First) or isinstance(tree1,Last) or isinstance(tree1,Exists):
         return isincluded(tree1.list,tree2.list)
     # Intersection, Union, And, Or
+    if len(tree1.list) != len(tree2.list):
+        return False
     for elt in tree1.list:
         if not any(isincluded(elt,x) for x in tree2.list):
             return False

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -30,4 +30,10 @@ def isincluded(tree1,tree2):
             isincluded(tree1.object,tree2.object)
     if isinstance(tree1,Sort):
         return tree1.predicate == tree2.predicate and isincluded(tree1.list,tree2.list)
-    return isincluded(tree1.list,tree2.list)
+    if isinstance(tree1,First) or isinstance(tree1,Last) or isinstance(tree1,Exists):
+        return isincluded(tree1.list,tree2.list)
+    # Intersection, Union, And, Or
+    for elt in tree1.list:
+        if not any(isincluded(elt,x) for x in tree2.list):
+            return False
+    return True

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -1,6 +1,6 @@
 """Utilities for using the PPP datamodel."""
 
-from . import Resource, Triple, Missing, Intersection, List, Union, And, Or, Exist, First, Last, Sort
+from . import Resource, Triple, Missing, Intersection, List, Union, And, Or, Exists, First, Last, Sort
 
 def contains_missing(tree):
     def predicate(node, childs):
@@ -20,6 +20,8 @@ def isincluded(tree1,tree2):
         tree2=List([tree2])
     if type(tree1) != type(tree2):
         return False
+    if isinstance(tree1,Missing):
+        return True
     if isinstance(tree1,List):
         return set(tree1.list).issubset(set(tree2.list))
     if isinstance(tree1,Triple):

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -75,12 +75,10 @@ class InclusionTestCase(unittest.TestCase):
         """
         Return True if and only if l contains elt (in the isincluded meaning).
         """
-        included = False
         for elt2 in l:
             try:
                 self.assertIncluded(elt, elt2, None, None)
             except AssertionError:
                 continue
-            included = True
-            break
-        return included
+            return True
+        return False

--- a/ppp_datamodel/utils.py
+++ b/ppp_datamodel/utils.py
@@ -11,67 +11,76 @@ def contains_missing(tree):
             return any(childs.values())
     return tree.fold(predicate)
 
-class InclusionAssertion:
-
-    def isincluded(self,tree1, tree2, originalTree1, originalTree2):
+class InclusionTestCase(unittest.TestCase):
+    """
+    Unit test with a method for asserting inclusion of objects from the
+    datamodel.
+    """
+    def assertIncluded(self, tree1, tree2,
+                       originalTree1=None, originalTree2=None):
         """
-            Check wether tree1 is included in tree2.
-            originalTree1 and originalTree2 are the trees given at the call of assertIncluded.
+        Check wether tree1 is included in tree2.
+        originalTree1 and originalTree2 are the whole trees we run the
+        assertion on.
         """
-        if isinstance(tree1,Resource):
+        originalTree1 = originalTree1 or tree1
+        originalTree2 = originalTree2 or tree2
+        if isinstance(tree1, Resource):
             tree1=List([tree1])
-        if isinstance(tree2,Resource):
+        if isinstance(tree2, Resource):
             tree2=List([tree2])
         if type(tree1) != type(tree2):
-            raise AssertionError('Different types for %s and %s.\n%s ⊈ %s.' % (tree1, tree2, originalTree1, originalTree2))
+            raise AssertionError('Different types for %s and %s.\n%s ⊈ %s.' %
+                    (tree1, tree2, originalTree1, originalTree2))
         elif isinstance(tree1, Missing):
             return
         elif isinstance(tree1, List):
             if not set(tree1.list).issubset(set(tree2.list)):
-                raise AssertionError('List %s not included in List %s.\n%s ⊈ %s.' % (tree1, tree2, originalTree1, originalTree2))
+                raise AssertionError(
+                        'List %s not included in List %s.\n%s ⊈ %s.' %
+                        (tree1, tree2, originalTree1, originalTree2))
         elif isinstance(tree1, Triple):
-            return  self.isincluded(tree1.subject, tree2.subject, originalTree1, originalTree2) and\
-                self.isincluded(tree1.predicate, tree2.predicate, originalTree1, originalTree2) and\
-                self.isincluded(tree1.object, tree2.object)
-        elif isinstance(tree1,Sort):
+            self.assertIncluded(tree1.subject, tree2.subject,
+                    originalTree1, originalTree2)
+            self.assertIncluded(tree1.predicate, tree2.predicate,
+                        originalTree1, originalTree2)
+            self.assertIncluded(tree1.object, tree2.object)
+        elif isinstance(tree1, Sort):
             if tree1.predicate != tree2.predicate:
-                raise AssertionError('Different predicate: %s and %s.\n%s ⊈ %s.' % (tree1.predicate, tree2.predicate, originalTree1, originalTree2))
+                raise AssertionError(
+                        'Different predicate: %s and %s.\n%s ⊈ %s.' %
+                        (tree1.predicate, tree2.predicate,
+                            originalTree1, originalTree2))
             else:
-                return self.isincluded(tree1.list, tree2.list, originalTree1, originalTree2)
-        elif isinstance(tree1,(First, Last, Exists)):
-            return self.isincluded(tree1.list, tree2.list, originalTree1, originalTree2)
-        elif isinstance(tree1,(Intersection, Union, And, Or)):
+                self.assertIncluded(tree1.list, tree2.list,
+                        originalTree1, originalTree2)
+        elif isinstance(tree1, (First, Last, Exists)):
+            self.assertIncluded(tree1.list, tree2.list,
+                    originalTree1, originalTree2)
+        elif isinstance(tree1, (Intersection, Union, And, Or)):
             if len(tree1.list) != len(tree2.list):
-                raise AssertionError('Different list length for %s and %s.\n%s ⊈ %s.' % (tree1, tree2, originalTree1, originalTree2))
+                raise AssertionError(
+                        'Different list length for %s and %s.\n%s ⊈ %s.' %
+                        (tree1, tree2, originalTree1, originalTree2))
             for elt in tree1.list:
-                if not self.contains(elt,tree2.list):
-                    raise AssertionError('%s does not belong to %s.\n%s ⊈ %s.' % (elt, tree2.list, originalTree1, originalTree2))
+                if not self.contains(elt, tree2.list):
+                    raise AssertionError(
+                            '%s does not belong to %s.\n%s ⊈ %s.' %
+                            (elt, tree2.list, originalTree1, originalTree2))
             return
         else:
             raise Exception('Unknown class.')
 
-    def contains(self,elt,l):
+    def contains(self, elt, l):
         """
-            Return True if and only if l contains elt (in the isincluded meaning).
+        Return True if and only if l contains elt (in the isincluded meaning).
         """
         included = False
         for elt2 in l:
             try:
-                self.isincluded(elt,elt2,None,None)
+                self.assertIncluded(elt, elt2, None, None)
             except AssertionError:
                 continue
             included = True
             break
         return included
-
-    def assertIncluded(self,tree1,tree2):
-        """
-            Check wether tree1 is included in tree2.
-        """
-        return self.isincluded(tree1,tree2,tree1,tree2)
-
-class InclusionTest(unittest.TestCase, InclusionAssertion):
-    """
-        Unit test for inclusion of objects from the datamodel.
-    """
-    pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,9 +31,15 @@ class UtilsTests(TestCase):
         l = [Resource('foo'),Missing(),Triple(Resource('foo'),Resource('foo'),Resource('foo')),\
             Intersection([Resource('foo')]), Union([Resource('foo')]),\
             And([Resource('foo')]), Or([Resource('foo')]), Exists(Resource('foo')),\
-            First(Resource('foo')), Last(Resource('foo')), Sort(Resource('foo'),'pred')]
+            First(Resource('foo')), Last(Resource('foo')), Sort(Resource('foo'),Resource('pred'))]
         for t1 in l:
             for t2 in l:
                 if type(t1) == type(t2):
                     break
                 self.assertFalse(f(t1,t2))
+    def testInclusionTriple(self):
+        f = utils.isincluded
+        tree1=Triple(Resource('foo'),List([Resource('a'),Resource('b')]),Missing())
+        tree2=Triple(List([Resource('bar'),Resource('foo')]),List([Resource('a'),Resource('d'),Resource('b')]),Missing())
+        self.assertTrue(f(tree1,tree2))
+        self.assertFalse(f(tree2,tree1))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from ppp_datamodel import Triple, Resource, Missing
+from ppp_datamodel import Resource, Triple, Missing, Intersection, Union, List, Union, And, Or, Exists, First, Last, Sort
 from ppp_datamodel import utils
 
 T = Triple
@@ -13,3 +13,27 @@ class UtilsTests(TestCase):
         self.assertTrue(f(T(subject=R(value='foo'), object=T(subject=M()))))
         self.assertFalse(f(T(subject=R(value='foo'), object=T(subject=R()))))
         self.assertTrue(f(M()))
+    def testInclusionBasic(self):
+        f = utils.isincluded
+        self.assertTrue(f(Missing(),Missing()))
+        self.assertTrue(f(Resource('foo'),Resource('foo')))
+        self.assertFalse(f(Resource('foo'),Resource('bar')))
+        self.assertTrue(f(List([Resource('foo')]),Resource('foo')))
+        self.assertFalse(f(List([Resource('foo')]),Resource('bar')))
+        self.assertTrue(f(Resource('foo'),List([Resource('foo')])))
+        self.assertFalse(f(Resource('foo'),List([Resource('bar')])))
+        self.assertTrue(f(List([Resource('foo')]),List([Resource('foo')])))
+        self.assertFalse(f(List([Resource('foo')]),List([Resource('bar')])))
+        self.assertTrue(f(List([Resource('foo')]),List([Resource('foo'),Resource('bar')])))
+        self.assertFalse(f(List([Resource('foo'),Resource('bar')]),List([Resource('foo')])))
+    def testInclusionDifferentType(self):
+        f = utils.isincluded
+        l = [Resource('foo'),Missing(),Triple(Resource('foo'),Resource('foo'),Resource('foo')),\
+            Intersection([Resource('foo')]), Union([Resource('foo')]),\
+            And([Resource('foo')]), Or([Resource('foo')]), Exists(Resource('foo')),\
+            First(Resource('foo')), Last(Resource('foo')), Sort(Resource('foo'),'pred')]
+        for t1 in l:
+            for t2 in l:
+                if type(t1) == type(t2):
+                    break
+                self.assertFalse(f(t1,t2))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ class UtilsTests(TestCase):
         self.assertFalse(f(List([Resource('foo'), Resource('bar')]), List([Resource('foo')])))
     def testInclusionDifferentType(self):
         f = utils.isincluded
-        l = [Resource('foo'), Missing(), triple(Resource('foo'), Resource('foo'), Resource('foo')),\
+        l = [Resource('foo'), Missing(), Triple(Resource('foo'), Resource('foo'), Resource('foo')),\
             Intersection([Resource('foo')]), Union([Resource('foo')]),\
             And([Resource('foo')]), Or([Resource('foo')]), Exists(Resource('foo')),\
             First(Resource('foo')), Last(Resource('foo')), Sort(Resource('foo'), Resource('pred'))]
@@ -56,7 +56,7 @@ class UtilsTests(TestCase):
         tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
         tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
         tree3=Missing()
-        for op in [Intersection,Union,And, or]:
+        for op in [Intersection,Union,And, Or]:
             self.assertTrue(f(op([tree1]), op([tree2])))
             self.assertFalse(f(op([tree2]), op([tree1])))
             self.assertTrue(f(op([tree1, tree3]), op([tree1, tree3])))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,51 +15,64 @@ class UtilsTests(TestCase):
         self.assertFalse(f(T(subject=R(value='foo'), object=T(subject=R()))))
         self.assertTrue(f(M()))
     def testInclusionBasic(self):
-        f = utils.isincluded
-        self.assertTrue(f(Missing(), Missing()))
-        self.assertTrue(f(Resource('foo'), Resource('foo')))
-        self.assertFalse(f(Resource('foo'), Resource('bar')))
-        self.assertTrue(f(List([Resource('foo')]), Resource('foo')))
-        self.assertFalse(f(List([Resource('foo')]), Resource('bar')))
-        self.assertTrue(f(Resource('foo'), List([Resource('foo')])))
-        self.assertFalse(f(Resource('foo'), List([Resource('bar')])))
-        self.assertTrue(f(List([Resource('foo')]), List([Resource('foo')])))
-        self.assertFalse(f(List([Resource('foo')]), List([Resource('bar')])))
-        self.assertTrue(f(List([Resource('foo')]), List([Resource('foo'), Resource('bar')])))
-        self.assertFalse(f(List([Resource('foo'), Resource('bar')]), List([Resource('foo')])))
+        f = utils.InclusionAssertion().assertIncluded
+        f(Missing(), Missing())
+        f(Resource('foo'), Resource('foo'))
+        with self.assertRaises(AssertionError):
+            f(Resource('foo'), Resource('bar'))
+        f(List([Resource('foo')]), Resource('foo'))
+        with self.assertRaises(AssertionError):
+            f(List([Resource('foo')]), Resource('bar'))
+        f(Resource('foo'), List([Resource('foo')]))
+        with self.assertRaises(AssertionError):
+            f(Resource('foo'), List([Resource('bar')]))
+        f(List([Resource('foo')]), List([Resource('foo')]))
+        with self.assertRaises(AssertionError):
+            f(List([Resource('foo')]), List([Resource('bar')]))
+        f(List([Resource('foo')]), List([Resource('foo'), Resource('bar')]))
+        with self.assertRaises(AssertionError):
+            f(List([Resource('foo'), Resource('bar')]), List([Resource('foo')]))
     def testInclusionDifferentType(self):
-        f = utils.isincluded
+        f = utils.InclusionAssertion().assertIncluded
         l = [Resource('foo'), Missing(), Triple(Resource('foo'), Resource('foo'), Resource('foo')),\
             Intersection([Resource('foo')]), Union([Resource('foo')]),\
             And([Resource('foo')]), Or([Resource('foo')]), Exists(Resource('foo')),\
             First(Resource('foo')), Last(Resource('foo')), Sort(Resource('foo'), Resource('pred'))]
         for (t1, t2) in itertools.permutations(l, 2):
-            self.assertFalse(f(t1, t2))
+            with self.assertRaises(AssertionError):
+                self.assertFalse(f(t1, t2))
     def testInclusionTriple(self):
-        f = utils.isincluded
+        f = utils.InclusionAssertion().assertIncluded
         tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
         tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
-        self.assertTrue(f(tree1, tree2))
-        self.assertFalse(f(tree2, tree1))
+        f(tree1, tree2)
+        with self.assertRaises(AssertionError):
+            f(tree2, tree1)
     def testInclusionFirstLastSort(self):
-        f = utils.isincluded
+        f = utils.InclusionAssertion().assertIncluded
         tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
         tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
         for op in [Last,First]:
-            self.assertTrue(f(op(tree1), op(tree2)))
-            self.assertFalse(f(op(tree2), op(tree1)))
-        self.assertTrue(f(Sort(tree1, Resource('pred')), Sort(tree2, Resource('pred'))))
-        self.assertFalse(f(Sort(tree2, Resource('pred')), Sort(tree1, Resource('pred'))))
-        self.assertFalse(f(Sort(tree1, Resource('pred')), Sort(tree2, Resource('derp'))))
+            f(op(tree1), op(tree2))
+            with self.assertRaises(AssertionError):
+                f(op(tree2), op(tree1))
+        f(Sort(tree1, Resource('pred')), Sort(tree2, Resource('pred')))
+        with self.assertRaises(AssertionError):
+            f(Sort(tree2, Resource('pred')), Sort(tree1, Resource('pred')))
+        with self.assertRaises(AssertionError):
+            f(Sort(tree1, Resource('pred')), Sort(tree2, Resource('derp')))
     def testInclusionIntersectionUnionAndOr(self):
-        f = utils.isincluded
+        f = utils.InclusionAssertion().assertIncluded
         tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
         tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
         tree3=Missing()
         for op in [Intersection,Union,And, Or]:
-            self.assertTrue(f(op([tree1]), op([tree2])))
-            self.assertFalse(f(op([tree2]), op([tree1])))
-            self.assertTrue(f(op([tree1, tree3]), op([tree1, tree3])))
-            self.assertTrue(f(op([tree1, tree3]), op([tree3, tree1])))
-            self.assertFalse(f(op([tree1, tree3]), op([tree1])))
-            self.assertFalse(f(op([tree1]), op([tree3])))
+            f(op([tree1]), op([tree2]))
+            with self.assertRaises(AssertionError):
+                f(op([tree2]), op([tree1]))
+            f(op([tree1, tree3]), op([tree1, tree3]))
+            f(op([tree1, tree3]), op([tree3, tree1]))
+            with self.assertRaises(AssertionError):
+                f(op([tree1, tree3]), op([tree1]))
+            with self.assertRaises(AssertionError):
+                f(op([tree1]), op([tree3]))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,5 +88,5 @@ class UtilsTests(utils.InclusionTestCase):
     def testUnknownClass(self):
         class Foo:
             pass
-        with self.assertRaises(Exception):
-            utils.InclusionAssertion().assertIncluded(Foo(),Foo())
+        with self.assertRaises(TypeError):
+            self.assertIncluded(Foo(),Foo())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,7 @@ class UtilsTests(TestCase):
         tree2=Triple(List([Resource('bar'),Resource('foo')]),List([Resource('a'),Resource('d'),Resource('b')]),Missing())
         self.assertTrue(f(tree1,tree2))
         self.assertFalse(f(tree2,tree1))
-    def testFirstLastSort(self):
+    def testInclusionFirstLastSort(self):
         f = utils.isincluded
         tree1=Triple(Resource('foo'),List([Resource('a'),Resource('b')]),Missing())
         tree2=Triple(List([Resource('bar'),Resource('foo')]),List([Resource('a'),Resource('d'),Resource('b')]),Missing())
@@ -53,3 +53,16 @@ class UtilsTests(TestCase):
         self.assertTrue(f(Sort(tree1,Resource('pred')),Sort(tree2,Resource('pred'))))
         self.assertFalse(f(Sort(tree2,Resource('pred')),Sort(tree1,Resource('pred'))))
         self.assertFalse(f(Sort(tree1,Resource('pred')),Sort(tree2,Resource('derp'))))
+    def testInclusionIntersectionUnionAndOr(self):
+        f = utils.isincluded
+        tree=[None]*5
+        tree1=Triple(Resource('foo'),List([Resource('a'),Resource('b')]),Missing())
+        tree2=Triple(List([Resource('bar'),Resource('foo')]),List([Resource('a'),Resource('d'),Resource('b')]),Missing())
+        tree3=Missing()
+        for op in [Intersection,Union,And,Or]:
+            self.assertTrue(f(op([tree1]),op([tree2])))
+            self.assertFalse(f(op([tree2]),op([tree1])))
+            self.assertTrue(f(op([tree1,tree3]),op([tree1,tree3])))
+            self.assertTrue(f(op([tree1,tree3]),op([tree3,tree1])))
+            self.assertFalse(f(op([tree1,tree3]),op([tree1])))
+            self.assertFalse(f(op([tree1]),op([tree3])))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,3 +76,8 @@ class UtilsTests(TestCase):
                 f(op([tree1, tree3]), op([tree1]))
             with self.assertRaises(AssertionError):
                 f(op([tree1]), op([tree3]))
+    def testUnknownClass(self):
+        class Foo:
+            pass
+        with self.assertRaises(Exception):
+            utils.InclusionAssertion().assertIncluded(Foo(),Foo())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import itertools
 
 from ppp_datamodel import Resource, Triple, Missing, Intersection, Union, List, Union, And, Or, Exists, First, Last, Sort
 from ppp_datamodel import utils
@@ -15,54 +16,50 @@ class UtilsTests(TestCase):
         self.assertTrue(f(M()))
     def testInclusionBasic(self):
         f = utils.isincluded
-        self.assertTrue(f(Missing(),Missing()))
-        self.assertTrue(f(Resource('foo'),Resource('foo')))
-        self.assertFalse(f(Resource('foo'),Resource('bar')))
-        self.assertTrue(f(List([Resource('foo')]),Resource('foo')))
-        self.assertFalse(f(List([Resource('foo')]),Resource('bar')))
-        self.assertTrue(f(Resource('foo'),List([Resource('foo')])))
-        self.assertFalse(f(Resource('foo'),List([Resource('bar')])))
-        self.assertTrue(f(List([Resource('foo')]),List([Resource('foo')])))
-        self.assertFalse(f(List([Resource('foo')]),List([Resource('bar')])))
-        self.assertTrue(f(List([Resource('foo')]),List([Resource('foo'),Resource('bar')])))
-        self.assertFalse(f(List([Resource('foo'),Resource('bar')]),List([Resource('foo')])))
+        self.assertTrue(f(Missing(), Missing()))
+        self.assertTrue(f(Resource('foo'), Resource('foo')))
+        self.assertFalse(f(Resource('foo'), Resource('bar')))
+        self.assertTrue(f(List([Resource('foo')]), Resource('foo')))
+        self.assertFalse(f(List([Resource('foo')]), Resource('bar')))
+        self.assertTrue(f(Resource('foo'), List([Resource('foo')])))
+        self.assertFalse(f(Resource('foo'), List([Resource('bar')])))
+        self.assertTrue(f(List([Resource('foo')]), List([Resource('foo')])))
+        self.assertFalse(f(List([Resource('foo')]), List([Resource('bar')])))
+        self.assertTrue(f(List([Resource('foo')]), List([Resource('foo'), Resource('bar')])))
+        self.assertFalse(f(List([Resource('foo'), Resource('bar')]), List([Resource('foo')])))
     def testInclusionDifferentType(self):
         f = utils.isincluded
-        l = [Resource('foo'),Missing(),Triple(Resource('foo'),Resource('foo'),Resource('foo')),\
+        l = [Resource('foo'), Missing(), triple(Resource('foo'), Resource('foo'), Resource('foo')),\
             Intersection([Resource('foo')]), Union([Resource('foo')]),\
             And([Resource('foo')]), Or([Resource('foo')]), Exists(Resource('foo')),\
-            First(Resource('foo')), Last(Resource('foo')), Sort(Resource('foo'),Resource('pred'))]
-        for t1 in l:
-            for t2 in l:
-                if type(t1) == type(t2):
-                    break
-                self.assertFalse(f(t1,t2))
+            First(Resource('foo')), Last(Resource('foo')), Sort(Resource('foo'), Resource('pred'))]
+        for (t1, t2) in itertools.permutations(l, 2):
+            self.assertFalse(f(t1, t2))
     def testInclusionTriple(self):
         f = utils.isincluded
-        tree1=Triple(Resource('foo'),List([Resource('a'),Resource('b')]),Missing())
-        tree2=Triple(List([Resource('bar'),Resource('foo')]),List([Resource('a'),Resource('d'),Resource('b')]),Missing())
-        self.assertTrue(f(tree1,tree2))
-        self.assertFalse(f(tree2,tree1))
+        tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
+        tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
+        self.assertTrue(f(tree1, tree2))
+        self.assertFalse(f(tree2, tree1))
     def testInclusionFirstLastSort(self):
         f = utils.isincluded
-        tree1=Triple(Resource('foo'),List([Resource('a'),Resource('b')]),Missing())
-        tree2=Triple(List([Resource('bar'),Resource('foo')]),List([Resource('a'),Resource('d'),Resource('b')]),Missing())
+        tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
+        tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
         for op in [Last,First]:
-            self.assertTrue(f(op(tree1),op(tree2)))
-            self.assertFalse(f(op(tree2),op(tree1)))
-        self.assertTrue(f(Sort(tree1,Resource('pred')),Sort(tree2,Resource('pred'))))
-        self.assertFalse(f(Sort(tree2,Resource('pred')),Sort(tree1,Resource('pred'))))
-        self.assertFalse(f(Sort(tree1,Resource('pred')),Sort(tree2,Resource('derp'))))
+            self.assertTrue(f(op(tree1), op(tree2)))
+            self.assertFalse(f(op(tree2), op(tree1)))
+        self.assertTrue(f(Sort(tree1, Resource('pred')), Sort(tree2, Resource('pred'))))
+        self.assertFalse(f(Sort(tree2, Resource('pred')), Sort(tree1, Resource('pred'))))
+        self.assertFalse(f(Sort(tree1, Resource('pred')), Sort(tree2, Resource('derp'))))
     def testInclusionIntersectionUnionAndOr(self):
         f = utils.isincluded
-        tree=[None]*5
-        tree1=Triple(Resource('foo'),List([Resource('a'),Resource('b')]),Missing())
-        tree2=Triple(List([Resource('bar'),Resource('foo')]),List([Resource('a'),Resource('d'),Resource('b')]),Missing())
+        tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
+        tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
         tree3=Missing()
-        for op in [Intersection,Union,And,Or]:
-            self.assertTrue(f(op([tree1]),op([tree2])))
-            self.assertFalse(f(op([tree2]),op([tree1])))
-            self.assertTrue(f(op([tree1,tree3]),op([tree1,tree3])))
-            self.assertTrue(f(op([tree1,tree3]),op([tree3,tree1])))
-            self.assertFalse(f(op([tree1,tree3]),op([tree1])))
-            self.assertFalse(f(op([tree1]),op([tree3])))
+        for op in [Intersection,Union,And, or]:
+            self.assertTrue(f(op([tree1]), op([tree2])))
+            self.assertFalse(f(op([tree2]), op([tree1])))
+            self.assertTrue(f(op([tree1, tree3]), op([tree1, tree3])))
+            self.assertTrue(f(op([tree1, tree3]), op([tree3, tree1])))
+            self.assertFalse(f(op([tree1, tree3]), op([tree1])))
+            self.assertFalse(f(op([tree1]), op([tree3])))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,3 +43,13 @@ class UtilsTests(TestCase):
         tree2=Triple(List([Resource('bar'),Resource('foo')]),List([Resource('a'),Resource('d'),Resource('b')]),Missing())
         self.assertTrue(f(tree1,tree2))
         self.assertFalse(f(tree2,tree1))
+    def testFirstLastSort(self):
+        f = utils.isincluded
+        tree1=Triple(Resource('foo'),List([Resource('a'),Resource('b')]),Missing())
+        tree2=Triple(List([Resource('bar'),Resource('foo')]),List([Resource('a'),Resource('d'),Resource('b')]),Missing())
+        for op in [Last,First]:
+            self.assertTrue(f(op(tree1),op(tree2)))
+            self.assertFalse(f(op(tree2),op(tree1)))
+        self.assertTrue(f(Sort(tree1,Resource('pred')),Sort(tree2,Resource('pred'))))
+        self.assertFalse(f(Sort(tree2,Resource('pred')),Sort(tree1,Resource('pred'))))
+        self.assertFalse(f(Sort(tree1,Resource('pred')),Sort(tree2,Resource('derp'))))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,74 +8,83 @@ T = Triple
 R = Resource
 M = Missing
 
-class UtilsTests(TestCase):
+class UtilsTests(utils.InclusionTestCase):
     def testContainsMissing(self):
         f = utils.contains_missing
         self.assertTrue(f(T(subject=R(value='foo'), object=T(subject=M()))))
         self.assertFalse(f(T(subject=R(value='foo'), object=T(subject=R()))))
         self.assertTrue(f(M()))
     def testInclusionBasic(self):
-        f = utils.InclusionAssertion().assertIncluded
-        f(Missing(), Missing())
-        f(Resource('foo'), Resource('foo'))
+        self.assertIncluded(Missing(), Missing())
+        self.assertIncluded(Resource('foo'), Resource('foo'))
         with self.assertRaises(AssertionError):
-            f(Resource('foo'), Resource('bar'))
-        f(List([Resource('foo')]), Resource('foo'))
+            self.assertIncluded(Resource('foo'), Resource('bar'))
+        self.assertIncluded(List([Resource('foo')]), Resource('foo'))
         with self.assertRaises(AssertionError):
-            f(List([Resource('foo')]), Resource('bar'))
-        f(Resource('foo'), List([Resource('foo')]))
+            self.assertIncluded(List([Resource('foo')]), Resource('bar'))
+        self.assertIncluded(Resource('foo'), List([Resource('foo')]))
         with self.assertRaises(AssertionError):
-            f(Resource('foo'), List([Resource('bar')]))
-        f(List([Resource('foo')]), List([Resource('foo')]))
+            self.assertIncluded(Resource('foo'), List([Resource('bar')]))
+        self.assertIncluded(List([Resource('foo')]), List([Resource('foo')]))
         with self.assertRaises(AssertionError):
-            f(List([Resource('foo')]), List([Resource('bar')]))
-        f(List([Resource('foo')]), List([Resource('foo'), Resource('bar')]))
+            self.assertIncluded(List([Resource('foo')]),
+                    List([Resource('bar')]))
+        self.assertIncluded(List([Resource('foo')]),
+                List([Resource('foo'), Resource('bar')]))
         with self.assertRaises(AssertionError):
-            f(List([Resource('foo'), Resource('bar')]), List([Resource('foo')]))
+            self.assertIncluded(List([Resource('foo'), Resource('bar')]),
+                    List([Resource('foo')]))
     def testInclusionDifferentType(self):
-        f = utils.InclusionAssertion().assertIncluded
-        l = [Resource('foo'), Missing(), Triple(Resource('foo'), Resource('foo'), Resource('foo')),\
+        l = [Resource('foo'), Missing(), Triple(Resource('foo'),
+            Resource('foo'), Resource('foo')),\
             Intersection([Resource('foo')]), Union([Resource('foo')]),\
-            And([Resource('foo')]), Or([Resource('foo')]), Exists(Resource('foo')),\
-            First(Resource('foo')), Last(Resource('foo')), Sort(Resource('foo'), Resource('pred'))]
+            And([Resource('foo')]), Or([Resource('foo')]),
+            Exists(Resource('foo')), First(Resource('foo')),
+            Last(Resource('foo')), Sort(Resource('foo'), Resource('pred'))]
         for (t1, t2) in itertools.permutations(l, 2):
             with self.assertRaises(AssertionError):
-                self.assertFalse(f(t1, t2))
+                self.assertFalse(self.assertIncluded(t1, t2))
     def testInclusionTriple(self):
-        f = utils.InclusionAssertion().assertIncluded
-        tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
-        tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
-        f(tree1, tree2)
+        tree1=Triple(Resource('foo'),
+                List([Resource('a'), Resource('b')]), Missing())
+        tree2=Triple(List([Resource('bar'), Resource('foo')]),
+                List([Resource('a'), Resource('d'), Resource('b')]), Missing())
+        self.assertIncluded(tree1, tree2)
         with self.assertRaises(AssertionError):
-            f(tree2, tree1)
+            self.assertIncluded(tree2, tree1)
     def testInclusionFirstLastSort(self):
-        f = utils.InclusionAssertion().assertIncluded
-        tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
-        tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
+        tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]),
+                Missing())
+        tree2=Triple(List([Resource('bar'), Resource('foo')]),
+                List([Resource('a'), Resource('d'), Resource('b')]), Missing())
         for op in [Last,First]:
-            f(op(tree1), op(tree2))
+            self.assertIncluded(op(tree1), op(tree2))
             with self.assertRaises(AssertionError):
-                f(op(tree2), op(tree1))
-        f(Sort(tree1, Resource('pred')), Sort(tree2, Resource('pred')))
+                self.assertIncluded(op(tree2), op(tree1))
+        self.assertIncluded(Sort(tree1, Resource('pred')),
+                Sort(tree2, Resource('pred')))
         with self.assertRaises(AssertionError):
-            f(Sort(tree2, Resource('pred')), Sort(tree1, Resource('pred')))
+            self.assertIncluded(Sort(tree2, Resource('pred')),
+                    Sort(tree1, Resource('pred')))
         with self.assertRaises(AssertionError):
-            f(Sort(tree1, Resource('pred')), Sort(tree2, Resource('derp')))
+            self.assertIncluded(Sort(tree1, Resource('pred')),
+                    Sort(tree2, Resource('derp')))
     def testInclusionIntersectionUnionAndOr(self):
-        f = utils.InclusionAssertion().assertIncluded
-        tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]), Missing())
-        tree2=Triple(List([Resource('bar'), Resource('foo')]), List([Resource('a'), Resource('d'), Resource('b')]), Missing())
+        tree1=Triple(Resource('foo'), List([Resource('a'), Resource('b')]),
+                Missing())
+        tree2=Triple(List([Resource('bar'), Resource('foo')]),
+                List([Resource('a'), Resource('d'), Resource('b')]), Missing())
         tree3=Missing()
         for op in [Intersection,Union,And, Or]:
-            f(op([tree1]), op([tree2]))
+            self.assertIncluded(op([tree1]), op([tree2]))
             with self.assertRaises(AssertionError):
-                f(op([tree2]), op([tree1]))
-            f(op([tree1, tree3]), op([tree1, tree3]))
-            f(op([tree1, tree3]), op([tree3, tree1]))
+                self.assertIncluded(op([tree2]), op([tree1]))
+            self.assertIncluded(op([tree1, tree3]), op([tree1, tree3]))
+            self.assertIncluded(op([tree1, tree3]), op([tree3, tree1]))
             with self.assertRaises(AssertionError):
-                f(op([tree1, tree3]), op([tree1]))
+                self.assertIncluded(op([tree1, tree3]), op([tree1]))
             with self.assertRaises(AssertionError):
-                f(op([tree1]), op([tree3]))
+                self.assertIncluded(op([tree1]), op([tree3]))
     def testUnknownClass(self):
         class Foo:
             pass


### PR DESCRIPTION
Add a function to test wether a tree is included in another tree.

For instance, `("Le Petit Prince", "author", ?)`  ⊆ `("Le Petit Prince", ["author","writer"], ?)`.

This will be usefull for the unit tests of all the modules which produce triples (i.e., question parsing modules). It will allow to check a great number of input in a simpler way.


Next step is to code a generic function to do these unit tests.