### PR TITLE
Implement Triple.inverse.

### DIFF
--- a/ppp_datamodel/nodes/triple.py
+++ b/ppp_datamodel/nodes/triple.py
@@ -46,3 +46,7 @@ class Triple(AbstractNode):
             return frozenset(self.inverse_predicate.list)
         else:
             return frozenset({self.inverse_predicate})
+
+    def inverse(self):
+        return self.__class__(self.object, self.inverse_predicate,
+                self.subject, self.predicate)

--- a/tests/test_triple.py
+++ b/tests/test_triple.py
@@ -30,3 +30,9 @@ class BaseAbstractNodeTests(TestCase):
                  'subject': {'type': 'missing'},
                  'predicate': {'type': 'missing'},
                  'inverse-predicate': {'type': 'missing'}})
+
+    def testInverse(self):
+        self.assertEqual(T(R('foo'), R('bar'), R('baz'), R('qux')).inverse(),
+                T(R('baz'), R('qux'), R('foo'), R('bar')))
+        self.assertEqual(T(R('foo'), R('bar'), R('baz')).inverse(),
+                T(R('baz'), List([]), R('foo'), R('bar')))


### PR DESCRIPTION
This method returns an equivalent triple, with the predicate/inverse-predicates and object/subject swapped.