### PR TITLE
Split AbstractNode into four classes.

### DIFF
--- a/ppp_datamodel/__init__.py
+++ b/ppp_datamodel/__init__.py
@@ -1,4 +1,5 @@
 """Classes representing the data model of the Projet Pensées Profondes."""
 
+from .utils import *
 from .nodes import *
 from .communication import *

--- a/ppp_datamodel/utils/__init__.py
+++ b/ppp_datamodel/utils/__init__.py
@@ -1,0 +1,3 @@
+from .tests import contains_missing, InclusionTestCase
+from .attributesholder import AttributesHolder
+from .typedattributesholder import TypedAttributesHolder

--- a/ppp_datamodel/utils/attributesholder.py
+++ b/ppp_datamodel/utils/attributesholder.py
@@ -1,0 +1,69 @@
+from .. import exceptions
+from ..log import logger
+
+class AttributesHolder:
+    """Stores attributes and provides read-only access to them."""
+    __slots__ = ('_attributes')
+    _possible_attributes = None
+    def __init__(self, *args, **attributes):
+        attributes.update(dict(zip(self._possible_attributes, args)))
+        self._check_attributes(attributes)
+        self._parse_attributes(attributes)
+
+    def _check_attributes(self, attributes, extra=None):
+        """Check if attributes given to the constructor can be used to
+        instanciate a valid node."""
+        extra = extra or ()
+        unknown_keys = set(attributes) - set(self._possible_attributes) - set(extra)
+        if unknown_keys:
+            logger.warning('%s got unknown attributes: %s' %
+                            (self.__class__.__name__, unknown_keys))
+
+    def __repr__(self):
+        return '<%s %r>' % (self.__class__.__name__,
+                {x:y for (x,y) in self._attributes.items()})
+
+    def _parse_attributes(self, attributes):
+        self._attributes = attributes
+
+    def __eq__(self, other):
+        """Tests equality with another AttributesHolder instance."""
+        if isinstance(other, AttributesHolder):
+            return self._attributes == other._attributes
+        else:
+            return False
+
+    def __hash__(self):
+        return hash(frozenset(self._attributes.items()))
+
+    def get(self, name, strict=True):
+        """Get an attribute of the holder (read-only access)."""
+        if not isinstance(name, str) or name.startswith('_'):
+            raise AttributeError(self.__class__.__name__, name)
+        elif strict and name not in self._possible_attributes:
+            raise AttributeError('%s is not a valid attribute of %r.' %
+                                 (name, self))
+        elif name in self._attributes:
+            return self._attributes[name]
+        else:
+            raise exceptions.AttributeNotProvided(name)
+    __getattr__ = __getitem__ = get
+
+    def __setattr__(self, name, value):
+        if name.startswith('_'):
+            super().__setattr__(name, value)
+        else:
+            raise TypeError('%s\'s attributes are not settable.' %
+                    self.__class__.__name__)
+    def __delattr__(self, name):
+        if name.startswith('_'):
+            super().__delattr__(name, value)
+        else:
+            raise TypeError('%s\'s attributes are not settable.' %
+                    self.__class__.__name__)
+
+    def has(self, name):
+        """Check existence of an attribute."""
+        return name in self._attributes
+    __hasattr__ = __contains__ = has
+

--- a/ppp_datamodel/utils/tests.py
+++ b/ppp_datamodel/utils/tests.py
@@ -1,6 +1,6 @@
-"""Utilities for using the PPP datamodel."""
+"""Utilities for making tests on datamodel objects."""
 
-from . import Resource, Triple, Missing, Intersection, List, Union, And, Or, Exists, First, Last, Sort
+from ..nodes import Resource, Triple, Missing, Intersection, List, Union, And, Or, Exists, First, Last, Sort
 import unittest
 
 def contains_missing(tree):

--- a/ppp_datamodel/utils/typedattributesholder.py
+++ b/ppp_datamodel/utils/typedattributesholder.py
@@ -1,0 +1,39 @@
+from .attributesholder import AttributesHolder
+
+class TypedAttributesHolder(AttributesHolder):
+    """AttributesHolder with a special attributes holding type."""
+    __slots__ = ()
+    _type = None
+    def __init__(self, *args, **attributes):
+        # Sanity checks
+        if self._type is None or self._possible_attributes is None:
+            raise TypeError('%s is an abstract class.' % self.__class__)
+        super(TypedAttributesHolder, self).__init__(*args, **attributes)
+
+        self._attributes['type'] = self.type
+
+    def _check_attributes(self, attributes, extra=None):
+        if 'type' in attributes:
+            assert attributes.pop('type') == self.type
+        return super(TypedAttributesHolder, self) \
+                ._check_attributes(attributes, extra)
+
+    @property
+    def type(self):
+        """Type of the node."""
+        return self._type
+
+    def __repr__(self):
+        return '<PPP node "%s" %r>' % (self.type,
+                {x:y for (x,y) in self._attributes.items() if x != 'type'})
+
+    def __eq__(self, other):
+        """Tests equality with another AttributesHolder instance."""
+        if isinstance(other, dict):
+            return self.as_dict() == other
+        else:
+            return super(TypedAttributesHolder, self).__eq__(other)
+
+    def __hash__(self):
+        return hash(frozenset(self._attributes.items()))
+


### PR DESCRIPTION
AttributesHolder -> TypedAttributesHolder -> SerializableAttributesHolder -> AbstractNode

AttributesHolder and TypedAttributesHolder: theoretical part of the datamodel specification
SerializableAttributesHolder: serialization part of the spec
AbstractNode: utilities for making operations on trees.