### PR TITLE
In communication objects, raise appropriate type of exception if attributes do not validate.

### DIFF
--- a/ppp_datamodel/communication/request.py
+++ b/ppp_datamodel/communication/request.py
@@ -4,6 +4,7 @@ import json
 from .traceitem import TraceItem
 from ..nodes import AbstractNode
 from .traceitem import TraceItem
+from ..exceptions import AttributeNotProvided
 from ..utils import SerializableAttributesHolder
 
 if sys.version_info[0] >= 3:
@@ -18,13 +19,17 @@ class Request(SerializableAttributesHolder):
 
     def _check_attributes(self, attributes, extra=None):
         super(Request, self)._check_attributes(attributes)
-        assert {'id', 'language', 'tree'}.issubset(set(attributes.keys())), \
-                (attributes, extra)
-        assert isinstance(attributes['tree'], (basestring, AbstractNode))
-        assert isinstance(attributes['language'], basestring), attributes
-        assert isinstance(attributes['tree'], AbstractNode)
-        assert isinstance(attributes['measures'], dict)
-        assert isinstance(attributes['trace'], list)
+        missing_attributes = {'id', 'language', 'tree'} - set(attributes.keys())
+        if missing_attributes:
+            raise AttributeNotProvided('Missing attributes: %s' % ', '.join(missing_attributes))
+        if not isinstance(attributes['language'], basestring):
+            raise TypeError('"language" attribute is not a string.')
+        if not isinstance(attributes['tree'], AbstractNode):
+            raise TypeError('"tree" attribute is not an AbstractNode.')
+        if not isinstance(attributes['measures'], dict):
+            raise TypeError('"measures" attribute is not a dict.')
+        if not isinstance(attributes['trace'], list):
+            raise TypeError('"trace" attribute is not a list.')
 
     def _parse_attributes(self, attributes):
         attributes['measures'] = attributes.get('measures', {})

--- a/ppp_datamodel/communication/response.py
+++ b/ppp_datamodel/communication/response.py
@@ -3,6 +3,7 @@ import json
 
 from ..nodes import AbstractNode
 from .traceitem import TraceItem
+from ..exceptions import AttributeNotProvided
 from ..utils import SerializableAttributesHolder
 
 if sys.version_info[0] >= 3:
@@ -18,13 +19,17 @@ class Response(SerializableAttributesHolder):
 
     def _check_attributes(self, attributes, extra=None):
         super(Response, self)._check_attributes(attributes)
-        assert {'language', 'tree', 'measures', 'trace'} == \
-                set(attributes.keys()), (attributes, extra)
-        assert isinstance(attributes['tree'], (basestring, AbstractNode))
-        assert isinstance(attributes['language'], basestring), attributes
-        assert isinstance(attributes['tree'], AbstractNode)
-        assert isinstance(attributes['measures'], dict)
-        assert isinstance(attributes['trace'], list)
+        missing_attributes = {'language', 'tree', 'measures', 'trace'} - set(attributes.keys())
+        if missing_attributes:
+            raise AttributeNotProvided('Missing attributes: %s' % ', '.join(missing_attributes))
+        if not isinstance(attributes['language'], basestring):
+            raise TypeError('"language" attribute is not a string.')
+        if not isinstance(attributes['tree'], AbstractNode):
+            raise TypeError('"tree" attribute is not an AbstractNode.')
+        if not isinstance(attributes['measures'], dict):
+            raise TypeError('"measures" attribute is not a dict.')
+        if not isinstance(attributes['trace'], list):
+            raise TypeError('"trace" attribute is not a list.')
 
     def _parse_attributes(self, attributes):
         tree = attributes['tree']

--- a/ppp_datamodel/communication/traceitem.py
+++ b/ppp_datamodel/communication/traceitem.py
@@ -2,6 +2,7 @@ import sys
 import json
 
 from ..nodes import AbstractNode
+from ..exceptions import AttributeNotProvided
 from ..utils import SerializableAttributesHolder
 
 if sys.version_info[0] >= 3:
@@ -17,12 +18,17 @@ class TraceItem(SerializableAttributesHolder):
     def _check_attributes(self, attributes, extra=None):
         super(TraceItem, self)._check_attributes(attributes)
         # Allow missing 'time' attribute for now (transitioning)
-        assert {'module', 'tree', 'measures'}.issubset(set(attributes.keys())),\
-                (attributes, extra)
-        assert isinstance(attributes['module'], basestring), module
-        assert isinstance(attributes['tree'], AbstractNode)
-        assert isinstance(attributes['measures'], dict)
-        assert isinstance(attributes.get('times', {}), dict)
+        missing_attributes = {'module', 'tree', 'measures'} - set(attributes.keys())
+        if missing_attributes:
+            raise AttributeNotProvided('Missing attributes: %s' % ', '.join(missing_attributes))
+        if not isinstance(attributes['module'], basestring):
+            raise TypeError('"module" attribute is not a string.')
+        if not isinstance(attributes['tree'], AbstractNode):
+            raise TypeError('"tree" attribute is not an AbstractNode.')
+        if not isinstance(attributes['measures'], dict):
+            raise TypeError('"measures" attribute is not a dict.')
+        if 'times' in attributes and not isinstance(attributes['times'], dict):
+            raise TypeError('"times" attribute is not a dict.')
 
     def _parse_attributes(self, attributes):
         # Allow missing 'time' attribute for now (transitioning)


### PR DESCRIPTION
ie. TypeError if they are not the right type (consistent with nodes), and AttributeNotProvided if an attribute is missing.