### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://scrutinizer-ci.com/g/ProjetPP/PPP-datamodel-Python/badges/build.png?b=master)](https://scrutinizer-ci.com/g/ProjetPP/PPP-datamodel-Python/build-status/master)
 [![Code Coverage](https://scrutinizer-ci.com/g/ProjetPP/PPP-datamodel-Python/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/ProjetPP/PPP-datamodel-Python/?branch=master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ProjetPP/PPP-datamodel-Python/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/ProjetPP/PPP-datamodel-Python/?branch=master)
-[![PyPi version](https://pypip.in/v/ppp_datamodel/badge.png)](https://pypi.python.org/pypi/ppp_datamodel)
+[![PyPi version](https://img.shields.io/pypi/v/ppp_datamodel.svg)](https://pypi.python.org/pypi/ppp_datamodel)
 
 
 # How to install


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ppp-datamodel))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ppp-datamodel`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.